### PR TITLE
fix:synced the environment s3 bucket for mlflow terraform and train.py

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -51,7 +51,7 @@ try:
 except ImportError:
     lgb = None  # type: ignore
 
-BUCKET_NAME = "fraud-detection-artifacts-nateeatsrice-2024"
+BUCKET_NAME = "fraud-detection-artifacts-nateeatsrice-2025"
 # Set MLflow tracking URI to S3
 mlflow.set_tracking_uri(f"s3://{BUCKET_NAME}/mlflow")
 


### PR DESCRIPTION
## Fix: S3 Bucket Name Mismatch

### **Changes Made**
- Standardized S3 bucket name to `fraud-detection-artifacts-nateeatsrice-2025` in `src/train.py`
- Bucket name now consistent with Terraform configuration
- MLflow can now successfully write to the correct S3 bucket

### **Issue**
Fixes #1

### **Type of Change**
- [x] Bug fix 

### **Testing Done**
- [ ] Ran training script and verified MLflow logs to S3 successfully
- [ ] Terraform plan shows no changes to bucket resource
- [ ] CI/CD pipeline completes without errors

### **Additional Notes**
This is a quick fix. For a more robust solution, we should:
1. Move bucket name to environment variable
2. Create centralized configuration module
3. Add validation tests for config consistency

See Issue #1  for follow-up work.