### PR TITLE
FIX: Add Lambda packaging step before Terraform

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
+      
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -62,6 +62,13 @@ jobs:
         # with:
         #   role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         #   aws-region: ${{ env.AWS_REGION }}
+
+      - name: Package Lambda function
+        run: |
+          echo "Packaging Lambda function..."
+          cd lambda && zip -r ../lambda_function_payload.zip . -x "*.pyc" -x "__pycache__/*"
+          echo "Lambda zip created"
+          ls -la ../lambda_function_payload.zip
 
       - name: Log in to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
## Summary

closes #14 

Adds the missing Lambda packaging step to the CD workflow, fixing the Terraform failure.

## Problem

Terraform apply fails when `lambda_function_payload.zip` doesn't exist:

```
Error: Error in function call
  on main.tf line 312:
  filebase64sha256("../lambda_function_payload.zip")
  
Call to function "filebase64sha256" failed: no file exists at ../lambda_function_payload.zip
```

The CI workflow packages Lambda (for validation), but CD was missing this step entirely.

## Solution

Added Lambda packaging step before Terraform init:

```yaml
- name: Package Lambda function
  run: |
    echo "📦 Packaging Lambda function..."
    cd lambda && zip -r ../lambda_function_payload.zip . -x "*.pyc" -x "__pycache__/*"
    echo "✅ Lambda package created"
    ls -la ../lambda_function_payload.zip
```

### Why This Location?

```
cd.yml Before:
  checkout → AWS creds → ECR login → Docker build → Terraform init → FAIL

cd.yml After:
  checkout → AWS creds → Package Lambda → ECR login → Docker build → Terraform init → SUCCESS
```
The zip must exist before any Terraform command runs.

## Testing

### Verify Locally
```bash
# Ensure the command works
cd lambda && zip -r ../lambda_function_payload.zip . -x "*.pyc" -x "__pycache__/*"
ls -la lambda_function_payload.zip

# Verify Terraform can read it
cd terraform
terraform init
terraform validate
```

### Verify in CI
- [ ] Push this branch
- [ ] Check GitHub Actions for any YAML syntax errors
- [ ] After merge, verify CD workflow passes Terraform steps

## Checklist

- [x] Lambda packaging step added
- [x] Step placed before Terraform init
- [x] Excludes unnecessary files (.pyc, __pycache__)
- [x] Includes verification output (ls -la)