### PR TITLE
feat(terraform): configure S3 remote state with locking

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "fraud-detection-tfstate-codespace-2026"
+    key          = "fraud-detection/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+}


### PR DESCRIPTION
## Summary

Store Terraform state in S3 so both local development and CD pipeline share the same state.
closes #22 

## Problem

CD pipeline failed with "already exists" errors because it had no access to local Terraform state.

## Solution

```hcl
terraform {
  backend "s3" {
    bucket       = "fraud-detection-tfstate-codespace-2026"
    key          = "fraud-detection/terraform.tfstate"
    region       = "us-east-2"
    use_lockfile = true
    encrypt      = true
  }
}
```

## Pre-PR Setup (Already Done)

- Created S3 bucket via CLI
- Created DynamoDB table for locking
- Migrated local state with `terraform init -migrate-state`