### PR TITLE
Enhancement/cd health checks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,13 +106,24 @@ jobs:
             --region us-east-2
             
       - name: Verify application health
+        working-directory: terraform
         run: |
           ALB_URL=$(terraform output -raw app_url)
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${ALB_URL}")
+          echo "🔍 Checking health at ${ALB_URL}..."
           
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Deployment healthy"
-          else
-            echo "❌ Health check failed: HTTP ${HTTP_CODE}"
-            exit 1
-          fi
+          # Retry a few times (ALB might need a moment)
+          for i in 1 2 3 4 5; do            # ← Loops 5 times
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${ALB_URL}" || echo "000")
+            
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✅ Deployment healthy! (HTTP ${HTTP_CODE})"
+              echo "🎉 Application live at: ${ALB_URL}"
+              exit 0                         # ← Success, exit loop
+            fi
+            
+            echo "Attempt ${i}: HTTP ${HTTP_CODE}, retrying in 10s..."
+            sleep 10                         # ← Wait 10 seconds before retry
+          done
+          
+          echo "❌ Health check failed after 5 attempts"
+          exit 1   


### PR DESCRIPTION
## Summary

Adds verification steps to ensure deployments actually succeed before marking the pipeline as complete.
closes #17 

## Problem

Pipeline completed successfully but didn't verify:
- ECS tasks started correctly
- Application is responding
- Health checks are passing

"Green pipeline" ≠ "Working deployment"

## Solution

### 1. Wait for ECS Stability
```yaml
aws ecs wait services-stable \
  --cluster fraud-detection-cluster \
  --services fraud-detection-service
```
Blocks until new tasks are healthy and old tasks drained.

### 2. HTTP Health Check
```yaml
curl -s -o /dev/null -w "%{http_code}" "${ALB_URL}"
```
Verifies app returns HTTP 200. Retries 5 times with 10s delays.

## Changes

| File | Change |
| `.github/workflows/cd.yml` | Add 2 verification steps after Terraform apply |

## Behavior

```
Before:
  Terraform apply → Done (but is it actually working? no clue)

After:
  Terraform apply → Wait for ECS → Health check → Done (verified!)
```